### PR TITLE
Release/1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,49 +187,53 @@ The top level project structure follows a responsibility structure:
 
 This section covers data type conversions that SDAS processes between PostgreSQL and Athena databases.
 
-| Source Data Type                 | Supported? | SDAS Data Type |
-| -------------------------------- | ---------- | -------------- |
-| bigint                           | Y          | bigint         |
-| bigserial                        | Y          | int            |
-| bit [ (n) ]                      | Y          | string         |
-| bit varying [ (n) ]              | Y          | string         |
-| boolean                          | Y          | boolean        |
-| box                              | Y          | string         |
-| bytea                            | Y          | string         |
-| character varying [ (n) ]        | Y          | string         |
-| cidr                             | Y          | string         |
-| circle                           | Y          | string         |
-| date                             | Y          | date           |
-| double precision                 | Y          | decimal(38,6)  |
-| inet                             | Y          | string         |
-| integer                          | Y          | int            |
-| interval [ fields ] [ (p) ]      | Y          | string         |
-| json                             | Y          | string         |
-| jsonb                            | Y          | string         |
-| lseg                             | Y          | string         |
-| macaddr                          | Y          | string         |
-| macaddr8                         | Y          | string         |
-| money                            | Y          | decimal(19,4)  |
-| numeric                          | Y          | int            |
-| path                             | Y          | string         |
-| pg_lsn                           | Y          | string         |
-| pg_snapshot                      | Y          | string         |
-| point                            | Y          | string         |
-| polygon                          | Y          | string         |
-| real                             | Y          | decimal(19,4)  |
-| smallint                         | Y          | int            |
-| smallserial                      | Y          | int            |
-| serial                           | Y          | int            |
-| text                             | Y          | string         |
-| time [ (p) ]                     | Y          | string         |
-| time [ (p) ] with time zone      | Y          | string         |
-| timestamp [ (p) ]                | Y          | timestamp      |
-| timestamp [ (p) ] with time zone | Y          | timestamp      |
-| tsquery                          | Y          | string         |
-| tsvector                         | Y          | string         |
-| txid_snapshot                    | Y          | string         |
-| uuid                             | Y          | string         |
-| xml                              | Y          | string         |
+| Source Data Type              | Supported? | SDAS Data Type |
+|-------------------------------|------------|---------------|
+| ARRAY                         | Y          | array         |
+| bigserial                     | Y          | int           |
+| bigint                        | Y          | bigint        |
+| bit [ (n) ]                   | Y          | string        |
+| bit varying [ (n) ]           | Y          | string        |
+| boolean                       | Y          | boolean       |
+| box                           | Y          | string        |
+| bytea                         | Y          | binary        |
+| character varying [ (n) ]     | Y          | string        |
+| cidr                          | Y          | string        |
+| circle                        | Y          | string        |
+| date                          | Y          | date          |
+| double precision              | Y          | decimal(38,6) |
+| inet                          | Y          | string        |
+| integer                       | Y          | int           |
+| interval [ fields ] [ (p) ]   | Y          | string        |
+| json                          | Y          | string        |
+| jsonb                         | Y          | string        |
+| lseg                          | Y          | string        |
+| macaddr                       | Y          | string        |
+| macaddr8                      | Y          | string        |
+| money                         | Y          | decimal(19,4) |
+| numeric                       | Y          | decimal(38,18)|
+| path                          | Y          | string        |
+| pg_lsn                        | Y          | string        |
+| pg_snapshot                   | Y          | string        |
+| point                         | Y          | string        |
+| polygon                       | Y          | string        |
+| real                          | Y          | decimal(19,4) |
+| serial                        | Y          | int           |
+| smallint                      | Y          | smallint      |
+| smallserial                   | Y          | int           |
+| text                          | Y          | string        |
+| time                          | Y          | string        |
+| time with time zone           | Y          | string        |
+| timestamp                     | Y          | string        |
+| timestamp with time zone      | Y          | string        |
+| timestamp without time zone   | Y          | string        |
+| tsquery                       | Y          | string        |
+| tsvector                      | Y          | string        |
+| txid_snapshot                 | Y          | string        |
+| USER-DEFINED                  | Y          | string        |
+| uuid                          | Y          | string        |
+| xml                           | Y          | string        |
+
 
 ## Troubleshooting
 

--- a/api/archive/source/get-schema/lib/postgresql.py
+++ b/api/archive/source/get-schema/lib/postgresql.py
@@ -41,7 +41,7 @@ def convert_schema(type):
     elif "box" in type:
         return "string"
     elif "bytea" in type:
-        return "string"
+        return "binary"
     elif "character" in type:
         return "string"
     elif "character" in type:
@@ -73,7 +73,7 @@ def convert_schema(type):
     elif "money" in type:
         return "decimal(19,4)"
     elif "numeric" in type:
-        return "int"
+        return "decimal(38,18)"
     elif "path" in type:
         return "string"
     elif "pg_lsn" in type:
@@ -87,17 +87,17 @@ def convert_schema(type):
     elif "real" in type:
         return "decimal(19,4)"
     elif "smallint" in type:
-        return "int"
+        return "smallint"
     elif "smallserial" in type:
         return "int"
     elif "serial" in type:
         return "int"
     elif "text" in type:
         return "string"
-    elif "time" in type:
-        return "string"
     elif "timestamp" in type:
         return "timestamp"
+    elif "time" in type:
+        return "string"
     elif "tsquery" in type:
         return "string"
     elif "tsvector" in type:
@@ -107,6 +107,10 @@ def convert_schema(type):
     elif "uuid" == type:
         return "string"
     elif "xml" in type:
+        return "string"
+    elif "ARRAY" in type:
+        return "array"
+    elif "USER-DEFINED" in type:
         return "string"
 
 
@@ -173,7 +177,6 @@ class Connection:
                     if len(rows) != 0:
                         row_list = []
                         for row in rows:
-                        
                             row_type = convert_schema(row[1])
                             row_list.append(
                                 {

--- a/api/archive/source/test-connection/main.py
+++ b/api/archive/source/test-connection/main.py
@@ -13,6 +13,15 @@ express or implied. See the License for the specific language governing
 permissions and limitations under the License.
 """
 
+"""
+This module contains an AWS Lambda function for testing database connections. It supports multiple database engines such 
+as MySQL, MSSQL, Oracle, and PostgreSQL. The function handles incoming requests to test database connectivity and 
+returns the connection status.
+
+It uses environment variables for configuration, has built-in logging capabilities, and includes functions for masking 
+sensitive data and building HTTP responses.
+"""
+
 import json
 import logging
 import os
@@ -31,6 +40,7 @@ if logger.hasHandlers():
     logger.setLevel(LOG_LEVEL)
 else:
     logging.basicConfig(level=LOG_LEVEL)
+
 
 # endregion
 
@@ -77,7 +87,7 @@ def lambda_handler(event, context):
                                       port,
                                       username,
                                       password,
-                                      database,)
+                                      database, )
         try:
             connected = connection.testConnection()
             response = {"connected": connected}
@@ -92,25 +102,24 @@ def lambda_handler(event, context):
         for owner in oracle_owner_list:
             try:
                 oracle_connection = oracle.Connection(hostname,
-                                                    port,
-                                                    username,
-                                                    password,
-                                                    database,
-                                                    owner)
+                                                      port,
+                                                      username,
+                                                      password,
+                                                      database,
+                                                      owner)
                 connected = oracle_connection.testConnection()
                 response = {"connected": connected}
                 return build_response(200, json.dumps(response))
             except Exception as ex:
                 logger.error(traceback.format_exc())
                 return build_response(500, "Server Error")
-            
+
     elif database_engine == "mssql":
-        print("mssql")
         connection = mssql.Connection(hostname,
                                       port,
                                       username,
                                       password,
-                                      database,)
+                                      database, )
         try:
             connected = connection.testConnection()
             response = {"connected": connected}
@@ -121,10 +130,10 @@ def lambda_handler(event, context):
 
     elif database_engine == "postgresql":
         connection = postgresql.Connection(hostname,
-                                      port,
-                                      username,
-                                      password,
-                                      database,)
+                                           port,
+                                           username,
+                                           password,
+                                           database, )
         try:
             connected = connection.testConnection()
             response = {"connected": connected}
@@ -133,8 +142,7 @@ def lambda_handler(event, context):
             logger.error(traceback.format_exc())
             return build_response(500, "Server Error")
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
     example_event = {}
     response = lambda_handler(example_event, {})
-    print(json.dumps(response))

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdk",
-  "version": "0.0.1",
+  "version": "1.1.2",
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdas",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "scripts": {
     "start": "cd web-app && npm run start",
     "build": "python3 build.py",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sdas-web-app",
-    "version": "1.0.0",
+    "version": "1.1.2",
     "private": true,
     "dependencies": {
         "@aws-amplify/ui-react": "^4.3.6",

--- a/web-app/src/pages/AddArchive/DatabaseSettingsPanel.jsx
+++ b/web-app/src/pages/AddArchive/DatabaseSettingsPanel.jsx
@@ -81,54 +81,34 @@ export default function DatabaseSettingsPanel({
 
     const testConnection = async (e) => {
         setDatabaseConnecting(true);
+
         const myInit = {
             body: {
                 database_engine: databaseEngine,
-                oracle_owner:
-                    archivePanelData.oracleOwner === undefined
-                        ? ""
-                        : archivePanelData.oracleOwner,
-                hostname:
-                    archivePanelData.databaseHostname === undefined
-                        ? ""
-                        : archivePanelData.databaseHostname,
-                port:
-                    archivePanelData.databasePort === undefined
-                        ? ""
-                        : archivePanelData.databasePort,
-                username:
-                    archivePanelData.databaseUsername === undefined
-                        ? ""
-                        : archivePanelData.databaseUsername,
-                password:
-                    archivePanelData.databasePassword === undefined
-                        ? ""
-                        : archivePanelData.databasePassword,
-                database:
-                    archivePanelData.databaseName === undefined
-                        ? ""
-                        : archivePanelData.databaseName,
-                archive_name:
-                    archivePanelData.archiveName === undefined
-                        ? ""
-                        : archivePanelData.archiveName,
-                mode:
-                    archivePanelData.databaseMode === undefined
-                        ? ""
-                        : archivePanelData.databaseMode,
+                oracle_owner: archivePanelData.oracleOwner || "",
+                hostname: archivePanelData.databaseHostname || "",
+                port: archivePanelData.databasePort || "",
+                username: archivePanelData.databaseUsername || "",
+                password: archivePanelData.databasePassword || "",
+                database: archivePanelData.databaseName || "",
+                archive_name: archivePanelData.archiveName || "",
+                mode: archivePanelData.databaseMode || "",
             },
         };
 
         setDatabaseConnectionState(myInit);
-        const response = await API.post(
-            "api",
-            "api/archive/source/test-connection",
-            myInit
-        );
-        setDatabaseConnected(response["connected"]);
-        setDatabaseConnecting(false);
-        setDatabaseTestExecuted(true);
+
+        try {
+            const response = await API.post("api", "api/archive/source/test-connection", myInit);
+            setDatabaseConnected(response["connected"]);
+        } catch (error) {
+            setDatabaseConnected(false);
+        } finally {
+            setDatabaseConnecting(false);
+            setDatabaseTestExecuted(true);
+        }
     };
+
 
     const isEnable =
         archivePanelData.archiveName !== undefined &&


### PR DESCRIPTION
**Release v1.1.2 - "Fixes"**

**Fix:**

- Datatype conversions for PostgreSQL, types updated to their respective Athena schema representations that caused "Unsupported case of DataType" errors:

| Source Data Type | SDAS Data Type  |
|------------------|-----------------|
| ARRAY            | array           |
| bytea            | binary          |
| numeric          | decimal(38,18) |
| smallint         | smallint        |
| timestamp        | string          |
| USER-DEFINED     | string          |

**Documentation Updates:**

- Updated the README with detailed information on using the new supported datatypes.