### PR TITLE
fix: Correct Job Status Handling in getDatabaseSchema Function

### DIFF
--- a/web-app/src/pages/AddArchive/TableDetailsPanel.jsx
+++ b/web-app/src/pages/AddArchive/TableDetailsPanel.jsx
@@ -69,7 +69,7 @@ export default function TableDetailsPanel({
 
             // Polling for job completion
             let jobStatus = 'Pending';
-            while (jobStatus === 'Pending') {
+            while (jobStatus === 'Pending' || jobStatus === 'In Progress') {
                 await new Promise(resolve => setTimeout(resolve, 5000)); // Wait for 5 seconds before checking status
                 jobStatus = await checkJobStatus();
             }
@@ -92,7 +92,6 @@ export default function TableDetailsPanel({
             updateNestedProps(response);
         }
     };
-
 
     const updateNestedProps = (data) => {
         setDatabaseConnectionState(current => {


### PR DESCRIPTION
This commit addresses an issue in the getDatabaseSchema function where the job status 'In Progress' was incorrectly treated as a failure state. Changes include:

- Updated the polling logic to correctly handle 'In Progress' as an ongoing state, allowing the function to continue polling until the job reaches a 'Completed' state.
- Adjusted error handling to throw an error only if the job status is neither 'Pending', 'In Progress', nor 'Completed', indicating an actual failure or an unexpected status.

The revised function now properly waits for background processing to complete before fetching the results, enhancing reliability and accuracy of the job status checking mechanism.
